### PR TITLE
Aik format change

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -350,7 +350,7 @@ impl<'a> FobnailClient<'a> {
                                 }
                             },
                             n => {
-                                error!("Unsupported RSA key size {}", n);
+                                error!("Unsupported RSA key size {}", n * 8);
                                 *state = State::Idle {
                                     timeout: Some(get_time_ms() as u64 + 5000),
                                 };
@@ -559,6 +559,7 @@ impl<'a> FobnailClient<'a> {
     }
 
     fn verify_aik(aik: &AikKey) -> Result<(), ()> {
+        debug!("\n{:#04x?}\n", aik);
         Ok(())
     }
 }

--- a/src/client/proto.rs
+++ b/src/client/proto.rs
@@ -81,9 +81,9 @@ pub struct MetadataWithSignature<'a> {
     pub signature: &'a [u8],
 }
 
-#[derive(Deserialize)]
-pub struct RsaKey {
-    pub n: Vec<u8>,
+#[derive(Debug, Deserialize)]
+pub struct RsaKey<'a> {
+    pub n: &'a [u8],
     pub e: u32,
 }
 
@@ -94,13 +94,14 @@ pub enum KeyType {
     Rsa = 1,
 }
 
-#[derive(Deserialize)]
-pub struct AikKey {
+#[derive(Debug, Deserialize)]
+pub struct AikKey<'a> {
     #[serde(rename = "type")]
     pub key_type: KeyType,
     // cbor-smol (used by Trussed) does not implement `deserialize_any` so we
     // can't deserialize enums.
     // For now we need RSA only, and probably we won't any other keys for a long
     // time.
-    pub key: RsaKey,
+    #[serde(borrow)]
+    pub key: RsaKey<'a>,
 }

--- a/src/client/proto.rs
+++ b/src/client/proto.rs
@@ -104,4 +104,5 @@ pub struct AikKey<'a> {
     // time.
     #[serde(borrow)]
     pub key: RsaKey<'a>,
+    pub loaded_key_name: &'a [u8],
 }


### PR DESCRIPTION
With this change I can use one type 2 item for AIK modulus, instead of array of 256 type 0 items. Analogous change may be required for other components.