### PR TITLE
lfs: dirty hack for saving space on directory entries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ fn make_udp_socket(max_packet: usize, port: u16) -> UdpSocket<'static> {
 #[cfg_attr(target_os = "none", pal::cortex_m_rt::entry)]
 fn main() -> ! {
     pal::init();
-    let mut trussed_clients = pal::trussed::init(&["fobnail_client"]);
+    let mut trussed_clients = pal::trussed::init(&["trussed/"]);
     let trussed_fobnail_client = trussed_clients.pop().unwrap();
 
     let mut neighbor_cache_storage: [Option<(IpAddress, Neighbor)>; 16] = [None; 16];

--- a/tools/lfs/src/cert.rs
+++ b/tools/lfs/src/cert.rs
@@ -6,7 +6,7 @@ use sha2::Digest;
 
 use crate::Flash;
 
-const CERT_ROOT_DIR: &'static str = "/fobnail_client/dat/cert";
+const CERT_ROOT_DIR: &'static str = "/trussed/dat/cert";
 // These constants must match with definitions in certmgr/store.rs
 const ATTRIBUTE_CERTIFICATE_FLAGS: u8 = 0;
 const CERTIFICATE_FLAG_TRUSTED: u8 = 1;


### PR DESCRIPTION
This hack abuses lack of protection against path attacks in Trussed.
Normally 'trussed' is reserved client ID and Trussed tests it and
returns error, but if this ID is followed by path separator ('trussed/')
it passes. By doing this, all Fobnail data is saved under '/trussed/dat'
directory (which is created anyway by Trussed) instead of separate
'/fobnail_client/dat'.

This saves two 4KB blocks per directory, totaling up to 16KB of flash.

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>