### PR TITLE
Add missing /api/version endpoint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -145,6 +145,7 @@ async fn main() {
             .not_discoverable()
             .block_transfer()
             .resources(vec![
+                app::resource("/api/version").get(handle!(server::get_api_version)),
                 app::resource("/api/v1/admin/token_provision").post(handle!(
                     server::token_provisioning::token_provision_certchain
                 )),

--- a/src/server/proto.rs
+++ b/src/server/proto.rs
@@ -448,6 +448,11 @@ pub struct CredentialActivationResult<'a> {
     pub secret: &'a [u8],
 }
 
+#[derive(Serialize)]
+pub struct SupportedApiVersions<'a> {
+    pub versions: &'a [u32],
+}
+
 #[cfg(test)]
 mod tests {
     use core::marker::PhantomData;


### PR DESCRIPTION
Add /api/version endpoint which has been documented for some time already but not implemented until now.